### PR TITLE
In README, add how to change the default port for devserver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ In the working copy root, run the following command for the local devserver:
 
 .. code-block:: bash
 
-  env SITEURL=http://localhost:8000 make devserver
+  env SITEURL=http://localhost:8000 make devserver [PORT=8000]
 
 Branch convention
 =================


### PR DESCRIPTION
I think it's good to show this example in the README:

```bash
env SITEURL=http://localhost:8000 make devserver [PORT=8000]
```