### PR TITLE
Use more 'mathematical' symbols for the dynamic background

### DIFF
--- a/theme/templates/cover.html
+++ b/theme/templates/cover.html
@@ -26,7 +26,7 @@
   // canvas settings
   var min_width = 1920;
   var font_size = 12;
-  char_list = ["0", "1", ""]
+  char_list = ["𝜕", "𝛼", "𝜀", "𝜉", "𝜂", "𝜋", "𝜌", "𝜙", ""]
   var drops = [];
   c.height = c.parentElement.clientHeight;
   c.width = window.innerWidth > min_width ? window.innerWidth : min_width;


### PR DESCRIPTION
Use the following characters to replace "0", and "1" in the dynamic background: "𝜕", "𝛼", "𝜀", "𝜉", "𝜂", "𝜋", "𝜌", "𝜙".