### PR TITLE
Remove telegram information from the web page

### DIFF
--- a/content/pages/about.rst
+++ b/content/pages/about.rst
@@ -10,7 +10,6 @@ Contact us
 
 * Twitter: https://twitter.com/sciwork
 * Discord: https://discord.gg/6MAkFrD
-* Telegram group (online chatroom): https://t.me/sciwork2020
 * Email: contact@sciwork.dev
 
 Related links

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -85,9 +85,6 @@
       <i class="fas fa-circle fa-stack-2x text-white"></i>
       <i class="fab fa-twitter fa-stack-1x text-gray-800" style="padding: 0.1rem 0 0 0.1rem"></i>
     </a>
-    <a class="fa-stack" target="_blank" href="https://t.me/sciwork2020">
-      <i class="fab fa-telegram fa-stack-2x text-white"></i>
-    </a>
     <a class="fa-stack" target="_blank" href="mailto: contact@sciwork.dev">
       <i class="fas fa-circle fa-stack-2x text-white"></i>
       <i class="fas fa-envelope fa-stack-1x grey-text text-gray-800"></i>


### PR DESCRIPTION
I'd like to promote discord instead.