### PR TITLE
Add File-based configuration for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+publish = "output"
+command = "env SITEURL=$DEPLOY_PRIME_URL make deploy"
+
+
+[context.production.environment]
+command = "env SITEURL=$URL make deploy"

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -64,7 +64,7 @@
         <ul class="list-reset h-auto lg:flex justify-end flex-1 items-center text-right lg:text-2xl text-3xl" style="font-family: 'Yanone Kaffeesatz'">
           {% for title, link in MENUITEMS %}
             <li class="list-none lg:mr-4 mx-8 lg:py-0 pt-12">
-              <a href="{{ link }}" class="text-white no-underline hover:text-red-600">{{ title }}</a>
+              <a href="{{ SITEURL }}/{{ link }}" class="text-white no-underline hover:text-red-600">{{ title }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/theme/templates/disqus.html
+++ b/theme/templates/disqus.html
@@ -1,0 +1,16 @@
+{% if DISQUS_SITENAME %}
+<div class="comments">
+  <div id="disqus_thread"></div>
+  <script type="text/javascript">
+    var disqus_shortname = '{{ DISQUS_SITENAME }}';
+    var disqus_identifier = '{{ article.url }}';
+    var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+    (function() {
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the comments.</noscript>
+</div>
+{% endif %}


### PR DESCRIPTION
During a Netlify build, we need set different for each branch.

e.g.
The master branch `SITEURL` should be set to `https://sciwork.dev`,
and the other branches should be set to `https://{branch}--swportal.netlify.app`

But it's not configurable in the UI... A workaround is configure these settings in a netlify.toml

**Related links**
- [File-based configuration](https://docs.netlify.com/configure-builds/file-based-configuration/)
- [Deploy URLs and metadata](https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata)