### PR TITLE
[event] Add Pydoc ZH TW early July

### DIFF
--- a/content/pages/sprint/2021/07early-pycht.rst
+++ b/content/pages/sprint/2021/07early-pycht.rst
@@ -1,0 +1,72 @@
+===========================================
+Scisprint 2021 Early July: Python ZH TW Doc
+===========================================
+
+:date: 2021-06-29 15:24
+:url: sprint/2021/07early-pycht
+:save_as: sprint/2021/07early-pycht.html
+
+Scisprint 2021 Early July: Python ZH TW Doc
+===========================================
+
+This is the start of a series of sprints for translating `Python official
+document <https://docs.python.org/3/>`__ from English to traditional Chinese
+(Taiwan; ZH TW locale).  The agenda:
+
+* Improve the review.  Currently a bottleneck of the translation is the review
+  by Adrian.  It will be helpful to have more reviewers.
+
+* Improve glossary.  We have not had consistent translation of many English
+  words.  Find better ways to unify how terminology is translated.
+
+* Automation and CI.  We do not have any CI at the moment, but we should.  We
+  should check for build errors for each of the PRs, use of whites spaces, and
+  daily update of source strings.
+
+* Whether or not or how to use transifex.  The keys are how to improve the
+  pace of the translation, review, and integration of the current GitHub-based
+  flow.
+
+We are working on the 3.9 branch of the document:
+https://github.com/python/python-docs-zh-tw/tree/3.9.
+
+Registration
+------------
+
+Please join `gather.town <https://gather.town/app/yLTe8mBDb8pogMOX/sciwork>`_
+on the day of sprint!!
+
+Date & time
+-----------
+
+3rd July, Saturday, 2021, 09:00 -- 11:00 (AM)
+
+Agenda
+------
+
+* **08:30 -- 09:00**: Gathering
+* **09:00 -- 11:00**: Sprint
+
+Requirements
+------------
+
+A laptop or desktop to access gather.town_.  Mobile devices are known to have
+issues.
+
+Read the README of https://github.com/python/python-docs-zh-tw/tree/3.9.
+
+.. Sponsors
+.. --------
+
+Venue
+-----
+
+sciwork gather.town_.
+
+Contact us
+----------
+
+* Project telegram: https://t.me/PyDocTW
+* (sciwork) discord: https://discord.gg/RcAF6tDe7r
+* (sciwork) twitter: `@sciwork <https://twitter.com/sciwork>`__
+

--- a/content/pages/sprint/index.rst
+++ b/content/pages/sprint/index.rst
@@ -16,6 +16,9 @@ Scisprint 2021
 * `Scisprint 2021 Early July: solvcon devenv
   <{filename}2021/07early-devenv.rst>`__
 
+* `Scisprint 2021 Early July: Python ZH TW Doc
+  <{filename}2021/07early-pycht.rst>`__
+
 * `Scisprint 2021 Early of June: solvcon devenv
   <{filename}2021/06early-devenv.rst>`__
 


### PR DESCRIPTION
Add an (online) sprint for Python document ZH TW translation.  See recent discussions in https://t.me/PyDocTW.