### PR TITLE
Do not merge: wrong rendering of the a rst ordered list

### DIFF
--- a/content/pages/sprint/2022/07-taipei.rst
+++ b/content/pages/sprint/2022/07-taipei.rst
@@ -63,3 +63,17 @@ Contact us
 
 * Discord: https://discord.gg/6MAkFrD
 * Email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+
+Example to show the rendering issue of nested list
+
+#. `Intel Xeon Platinum 9282
+   <https://en.wikichip.org/wiki/intel/xeon_platinum/9282>`__
+
+   #. 56 cores
+   #. 77MB L3 cache memory
+
+#. `AMD EPYC 7H12
+   <https://www.amd.com/en/products/cpu/amd-epyc-7h12>`__
+
+   #. 64 cores
+   #. 256MB L3 cache memory


### PR DESCRIPTION
I was expecting the following rst rendered with a numbered list:

```rst
#. `Intel Xeon Platinum 9282
   <https://en.wikichip.org/wiki/intel/xeon_platinum/9282>`__

   #. 56 cores
   #. 77MB L3 cache memory

#. `AMD EPYC 7H12
   <https://www.amd.com/en/products/cpu/amd-epyc-7h12>`__

   #. 64 cores
   #. 256MB L3 cache memory
```

The HTML is generated as:

```html
<ol class="arabic simple">
<li><a class="reference external" href="https://en.wikichip.org/wiki/intel/xeon_platinum/9282">Intel Xeon Platinum 9282</a><ol class="arabic">
<li>56 cores</li>
<li>77MB L3 cache memory</li>
</ol>
</li>
<li><a class="reference external" href="https://www.amd.com/en/products/cpu/amd-epyc-7h12">AMD EPYC 7H12</a><ol class="arabic">
<li>64 cores</li>
<li>256MB L3 cache memory</li>
</ol>
</li>
</ol>
```

(Full HTML output is at https://deploy-preview-127--swportal.netlify.app/sprint/2022/07-taipei .)

But the list still shows bullet:

<img width="395" alt="Screen Shot 2022-09-11 at 09 04 43" src="https://user-images.githubusercontent.com/399122/189507324-dc277e2e-1f24-4c2a-a091-f513507d431f.png">
