### PR TITLE
Add after-event contents for scisprint February 2023

### DIFF
--- a/content/pages/sprint/2023/02-taipei.rst
+++ b/content/pages/sprint/2023/02-taipei.rst
@@ -10,7 +10,7 @@ Scisprint 2023 February at Amazon Taipei
 ========================================
 
 Thanks everyone for your enthutiastic participation in our February scisprint.
-A huge thanks to our sponsor Amazon for providing a great venue. We enjoy the time we shared in Amazon, hope to see you soon!
+Huge thanks to our sponsor Amazon for providing a great venue. We enjoy the time we shared in Amazon, hope to see you soon!
 
 https://medium.com/sciwork/scisprint-2023-february-in-taipei-e565f2d19b1a
 

--- a/content/pages/sprint/2023/02-taipei.rst
+++ b/content/pages/sprint/2023/02-taipei.rst
@@ -9,6 +9,26 @@ Scisprint 2023 February at Amazon Taipei
 Scisprint 2023 February at Amazon Taipei
 ========================================
 
+Thanks everyone for your enthutiastic participation in our February scisprint.
+A huge thanks to our sponsor Amazon for providing a great venue. We enjoy the time we shared in Amazon, hope to see you soon!
+
+https://medium.com/sciwork/scisprint-2023-february-in-taipei-e565f2d19b1a
+
+
+Event Album
+------------
+
+https://flic.kr/s/aHBqjArLL7
+
+.. raw:: html
+
+  <a data-flickr-embed="true" data-header="true" href="https://www.flickr.com/photos/sciwork/albums/72177720305939446" title="Scisprint 2023 February">
+    <img src="https://live.staticflickr.com/65535/52682729722_345427cd12_z.jpg" width="640" height="480" alt="Scisprint 2023 February">
+  </a>
+  <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+|
+
 * Date: 11th February, Saturday, 2023
 * Time: 10:00 -- 17:30 (7.5 hours)
 
@@ -68,23 +88,6 @@ https://hackmd.io/@sciwork/BJkd6Blts
 .. raw:: html
 
   <iframe width="100%" height="500" src="https://hackmd.io/@sciwork/BJkd6Blts" frameborder="0"></iframe>
-
-Event Album
-------------
-
-https://flic.kr/s/aHBqjArLL7
-
-.. raw:: html
-
-  <a data-flickr-embed="true" data-header="true" href="https://www.flickr.com/photos/sciwork/albums/72177720305939446" title="Scisprint 2023 February">
-    <img src="https://live.staticflickr.com/65535/52682729722_345427cd12_z.jpg" width="640" height="480" alt="Scisprint 2023 February">
-  </a>
-  <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
-
-Blog
-------
-
-https://medium.com/sciwork/scisprint-2023-february-in-taipei-e565f2d19b1a
 
 
 Contact us

--- a/content/pages/sprint/2023/02-taipei.rst
+++ b/content/pages/sprint/2023/02-taipei.rst
@@ -69,6 +69,24 @@ https://hackmd.io/@sciwork/BJkd6Blts
 
   <iframe width="100%" height="500" src="https://hackmd.io/@sciwork/BJkd6Blts" frameborder="0"></iframe>
 
+Event Album
+------------
+
+https://flic.kr/s/aHBqjArLL7
+
+.. raw:: html
+
+  <a data-flickr-embed="true" data-header="true" href="https://www.flickr.com/photos/sciwork/albums/72177720305939446" title="Scisprint 2023 February">
+    <img src="https://live.staticflickr.com/65535/52682729722_345427cd12_z.jpg" width="640" height="480" alt="Scisprint 2023 February">
+  </a>
+  <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+Blog
+------
+
+https://medium.com/sciwork/scisprint-2023-february-in-taipei-e565f2d19b1a
+
+
 Contact us
 ----------
 


### PR DESCRIPTION
Hi, @yungyuc and @cstnaya 

This PR is for addressed #165 by embedding the [Flickr album](https://www.flickr.com/photos/sciwork/albums/72177720305939446) and adding a link for the [blog](https://medium.com/sciwork/scisprint-2023-february-in-taipei-e565f2d19b1a)

I added a raw html to embedding the Flickr album. The reference doc is in [Share or embed Flickr photos/albums](https://www.flickrhelp.com/hc/en-us/articles/4404078014356-Share-or-embed-Flickr-photos-albums). 

I would like to use the group photo as album cover, which looks better. But it seems that it could not customize the album cover, which shows up the first photo of the album.

