### PR TITLE
add agenda to meetup 03-nycu.rst

### DIFF
--- a/content/pages/meetup/2023/03-nycu.rst
+++ b/content/pages/meetup/2023/03-nycu.rst
@@ -25,6 +25,24 @@ programming.
 We would like to provide a supportive and friendly environment for all attendees to support more developers
 to join in the open-source communities. 
 
+Topic Discussion
+-------------------
+
+We invite all attendees to suggest topics for the upcoming meetups, which will 
+feature approximately three 10-minute topics, and we welcome 
+suggestions from attendees. To list a few, the topic may be about Modmesh, NSD, 
+and NSD project, among others.
+
+Agenda 22nd March 2023
+-----------------------
+
+- 18:30-19:30 Disscussion.
+- 19:30-19:40 Topic discussion: Projection method. (EN)
+- 19:40-19:50 Topic discussion: Euler solver. (Chu-Hsu)
+- 19:50-20:00 Topic discussion: Camera. (TY)
+- 20:00-20:10 Scisprint recruitment. (Jenny)
+- 20:10- Discussion.
+
 Venue
 -----
 


### PR DESCRIPTION
This PR aim to avoid the problem occured in #190. This is the draft of the web page for the NYCU Meetup on March 22 to the Sciwork page. Currently, the agenda is located on the Sprint page, but we may move it to HackMD to increase flexibility. #189 