### PR TITLE
[meetup] sciwork volunteer training on 8/9

### DIFF
--- a/content/pages/meetup/2023/0809-nycu.rst
+++ b/content/pages/meetup/2023/0809-nycu.rst
@@ -1,0 +1,92 @@
+========================================
+Meetup 2023 August 9th in NYCU
+========================================
+
+:date: 2023-07-30 13:40
+:url: meetup/2023/0809-nycu
+:save_as: meetup/2023/0809-nycu.html
+
+Date
+-----
+
+* Date: August 9th, 2023
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+* 18:30-19:00 Free discussion
+* 19:00-20:30 Training: how to work out unknown things
+* 20:30-21:30 Free discussion
+
+|
+
+Training: how to work out unknown things
+----------------------------------------
+
+There are two types of things to do: what is well known and what is not known.
+Well-known things are easier to do, but also generally less valuable. This
+training is to help you find and understand the things that are not clearly
+defined, and provide an analytical framework to get them done.
+
+The sciwork events are of the unknown things. You will also learn how to
+contribute to sciwork.
+
+* 19:00-19:10 (10 min) Presentation: what are the things
+* 19:10-19:30 (20 min) Presentation: how to get things done
+* 19:30-19:45 (15 min) Dscussion: things you have done
+* 19:45-20:00 (15 min) Case study: sciwork meetup
+* 20:00-20:15 (15 min) Discussion: analyze the things you want to do
+* 20:15-20:30 (15 min) Hands-on: make the plan and review
+
+|
+
+Sign up
+------------
+
+TBD
+
+.. The event is free. Please register on `kktix
+.. <https://sciwork.kktix.cc/events/meetup-20230809>`__.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all 
+attendees to support more developers to join in the open-source communities. 
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+`國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU)
+<https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw" 
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* Discord: https://discord.gg/6MAkFrD
+* Email: `contact@sciwork.dev (subject: I want to lead a project in meetup)
+  <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__

--- a/content/pages/meetup/index.rst
+++ b/content/pages/meetup/index.rst
@@ -9,6 +9,9 @@ meetup
 meetup 2023
 ==============
 
+* `Meetup 2023 August 9th at NYCU
+  <{filename}2023/0809-nycu.rst>`__
+
 * `PyDoc Meetup 2023 August 5th at GoFreight Office
   <{filename}2023/0805-pydoc.rst>`__
 


### PR DESCRIPTION
I would like to propose to have a training for sciwork volunteers in the 8/9 meetup.  

The sciwork events require the ability to work on scopeless things. This training is to help traineers find and understand the things that are not clearly defined, and provide an analytical framework to get them done. The skills are readily applicable to contribution to sciwork.