### PR TITLE
Add photos for pydoc-meetup and scisprint 2023 August

### DIFF
--- a/content/pages/meetup/2023/0805-pydoc.rst
+++ b/content/pages/meetup/2023/0805-pydoc.rst
@@ -6,6 +6,29 @@ PyDoc Translation Meetup 2023 August 5th
 :url: meetup/2023/0805-pydoc
 :save_as: meetup/2023/0805-pydoc.html
 
+The PyDoc Translation Meetup ends successfully. Many thanks to **GoFreight** for 
+providing the great venue, as well as to all the participants who joined us. 
+Your generous support and active engagement played an important role in creating a 
+vibrant and inspiring atmosphere. We look forward to meeting you in the near future!
+
+Event Album
+------------
+
+https://flic.kr/s/aHBqjAR5Rf
+
+.. raw:: html
+
+  <a data-flickr-embed="true" data-footer="true" 
+    href="https://www.flickr.com/photos/sciwork/albums/72177720310487872" 
+    title="PyDoc Translation Meetup 2023 August 5th">
+      <img src="https://live.staticflickr.com/65535/53117111971_d38f14efd1_z.jpg" 
+      width="640" height="480" alt="PyDoc Translation Meetup 2023 August 5th"/>
+  </a>
+  <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+|
+|
+
 Date
 -----
 

--- a/content/pages/sprint/2023/08-hsinchu.rst
+++ b/content/pages/sprint/2023/08-hsinchu.rst
@@ -6,6 +6,28 @@ Scisprint 2023 August in Hsinchu
 :url: sprint/2023/08-hsinchu
 :save_as: sprint/2023/08-hsinchu.html
 
+The August sprint concluded on a positive note. Many thanks to **CTC (Center 
+for Theory and Computation, NTHU)** for providing the great venue, as well as 
+to all the participants who joined us. Your generous support and active engagement 
+played an important role in creating a vibrant and inspiring environment. We look 
+forward to meeting you again soon!
+
+Event Album
+------------
+
+.. raw:: html
+
+  <a data-flickr-embed="true" data-footer="true" 
+    href="https://www.flickr.com/photos/sciwork/albums/72177720310488272" 
+    title="Scisprint 2023 August">
+    <img src="https://live.staticflickr.com/65535/53116545547_e1d3c8a28d_z.jpg" 
+    width="640" height="480" alt="Scisprint 2023 August"/>
+  </a>
+  <script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+|
+|
+
 Date
 -----
 


### PR DESCRIPTION
Add photos for **PyDoc Translation Meetup 2023 August 5th** with [album link](https://flic.kr/s/aHBqjAR5Rf).

![image](https://github.com/sciwork/swportal/assets/55582907/a78e29f4-95b1-40d2-b91d-24af4ed2063e)

Add photos for **Scisprint 2023 August** with [album link](https://flic.kr/s/aHBqjAR5Y9).

![image](https://github.com/sciwork/swportal/assets/55582907/e836d3b6-85ab-4d16-90e5-860cb5a23708)
