### PR TITLE
Remove duplicated content in conference page

### DIFF
--- a/content/pages/conference/index.rst
+++ b/content/pages/conference/index.rst
@@ -15,4 +15,4 @@ to scientific computing and high-performance computing, we also emphasize data m
 process, analytics, and visualization.
 
 - Date: December 9-10, 2023
-- Location: Location: Microelectronics and Information Research Center, NYCU, Hsinchu, Taiwan
+- Location: Microelectronics and Information Research Center, NYCU, Hsinchu, Taiwan


### PR DESCRIPTION
Fix the issue from https://github.com/sciwork/swportal/pull/263#discussion_r1340789162 by removing duplicated `Location:`.