### PR TITLE
Fix the typo in the conference page

### DIFF
--- a/content/pages/conference/index.rst
+++ b/content/pages/conference/index.rst
@@ -6,10 +6,10 @@ Conference
 :url: conference
 :save_as: conference/index.html
 
-sicwork 2023
+sciwork 2023
 ================================================
     
-`sciwrok 2023 <https://conf.sciwork.dev>`__ is to provide a physical venue to showcase how programming languages are 
+`sciwork 2023 <https://conf.sciwork.dev>`__ is to provide a physical venue to showcase how programming languages are 
 used for scientific and engineering applications and their best practices. In addition 
 to scientific computing and high-performance computing, we also emphasize data management, 
 process, analytics, and visualization.


### PR DESCRIPTION
This PR is to fix the typo about `sciwork` in the [conference page](https://sciwork.dev/conference/)