### PR TITLE
HOTFIX: correct the workshop event title

### DIFF
--- a/content/pages/conference/2024/03-workshop.rst
+++ b/content/pages/conference/2024/03-workshop.rst
@@ -38,6 +38,10 @@ Agneda
 About the workshop
 ------------------
 
+We will invite professionals in numerical computing or software engineering relevant field to share their development
+experiences, facilitate discussions and exchanges among people in related fields, reduce the entry barriers to these fields, and
+establish active communities.
+
 Advanced CFD software development
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/content/pages/conference/2024/03-workshop.rst
+++ b/content/pages/conference/2024/03-workshop.rst
@@ -1,6 +1,6 @@
-===============================
-CFD workshop Hsinchu 2024 March
-===============================
+====================================================
+Advanced CFD software development Hsinchu 2024 March
+====================================================
 
 :date: 2024-02-28 9:41
 :url: workshop/2024/03-workshop
@@ -37,6 +37,9 @@ Agneda
 
 About the workshop
 ------------------
+
+Advanced CFD software development
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Speaker:** Yung-Yu Chen (https://yyc.solvcon.net/)
 

--- a/content/pages/conference/2024/03-workshop.rst
+++ b/content/pages/conference/2024/03-workshop.rst
@@ -38,12 +38,7 @@ Agneda
 About the workshop
 ------------------
 
-We will invite professionals in numerical computing or software engineering relevant field to share their development
-experiences, facilitate discussions and exchanges among people in related fields, reduce the entry barriers to these fields, and
-establish active communities.
-
-Advanced CFD software development
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Topic:** Advanced CFD software development
 
 **Speaker:** Yung-Yu Chen (https://yyc.solvcon.net/)
 

--- a/content/pages/conference/index.rst
+++ b/content/pages/conference/index.rst
@@ -23,9 +23,9 @@ report
 
 The event has concluded, and we appreciate everyone who participated! Feel free to review the report `here </conference/2023/report.html>`__!
 
-CFD workshop Hsinchu 2024 March
-================================
+Advanced CFD software development Hsinchu 2024 March
+====================================================
 
-The `CFD Workshop 2024 in March <{filename}2024/03-workshop.rst>`__ is a workshop focusing on scientific computing, engineering computation, and software 
+The `Advanced CFD software development 2024 in March <{filename}2024/03-workshop.rst>`__ is a workshop focusing on scientific computing, engineering computation, and software 
 engineering. The event will take place at the Engineering Building 3 at NYCU. If you are interested 
 in the aforementioned fields, come and join us!


### PR DESCRIPTION
I have corrected the workshop event title from **CFD workshop** to **Advanced CFD software development**.