### PR TITLE
HOTFIX: fix some date typo

### DIFF
--- a/content/pages/meetup/2024/0306-nycu.rst
+++ b/content/pages/meetup/2024/0306-nycu.rst
@@ -1,5 +1,5 @@
 ========================================
-Meetup 2024 March 6st in NYCU
+Meetup 2024 March 6th in NYCU
 ========================================
 
 :date: 2024-03-01 22:27
@@ -9,7 +9,7 @@ Meetup 2024 March 6st in NYCU
 Date
 -----
 
-* Date: March 6st, 2024
+* Date: March 6th, 2024
 * Time: 18:30 -- 21:30 (3 hours)
 
 |
@@ -27,12 +27,12 @@ There will be many different subjects discussed at the same time.
 Subjects
 ------------------
 
-Sciwork activity process automation discussion
+sciwork activity process automation discussion
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Meetup events are important within the Sciwork community, serving as hubs for discussions and knowledges sharing. 
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
 We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
-the power of CI/CD and cutting-edge IT skills to enhance the Sciwork event experience. The works are divided into : 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
 
 1. Decide the format of the meetup page.
 2. Create the sesh event with api or other method.

--- a/content/pages/meetup/2024/0313-nycu.rst
+++ b/content/pages/meetup/2024/0313-nycu.rst
@@ -1,5 +1,5 @@
 ========================================
-Meetup 2024 March 13st in NYCU
+Meetup 2024 March 13th in NYCU
 ========================================
 
 :date: 2024-03-01 22:27
@@ -9,7 +9,7 @@ Meetup 2024 March 13st in NYCU
 Date
 -----
 
-* Date: March 13st, 2024
+* Date: March 13th, 2024
 * Time: 18:30 -- 21:30 (3 hours)
 
 |
@@ -27,12 +27,12 @@ There will be many different subjects discussed at the same time.
 Subjects
 ------------------
 
-Sciwork activity process automation discussion
+sciwork activity process automation discussion
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Meetup events are important within the Sciwork community, serving as hubs for discussions and knowledges sharing. 
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
 We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
-the power of CI/CD and cutting-edge IT skills to enhance the Sciwork event experience. The works are divided into : 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
 
 1. Decide the format of the meetup page.
 2. Create the sesh event with api or other method.

--- a/content/pages/meetup/2024/0320-nycu.rst
+++ b/content/pages/meetup/2024/0320-nycu.rst
@@ -1,5 +1,5 @@
 ========================================
-Meetup 2024 March 20st in NYCU
+Meetup 2024 March 20th in NYCU
 ========================================
 
 :date: 2024-03-01 22:27
@@ -9,7 +9,7 @@ Meetup 2024 March 20st in NYCU
 Date
 -----
 
-* Date: March 20st, 2024
+* Date: March 20th, 2024
 * Time: 18:30 -- 21:30 (3 hours)
 
 |
@@ -27,12 +27,12 @@ There will be many different subjects discussed at the same time.
 Subjects
 ------------------
 
-Sciwork activity process automation discussion
+sciwork activity process automation discussion
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Meetup events are important within the Sciwork community, serving as hubs for discussions and knowledges sharing. 
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
 We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
-the power of CI/CD and cutting-edge IT skills to enhance the Sciwork event experience. The works are divided into : 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
 
 1. Decide the format of the meetup page.
 2. Create the sesh event with api or other method.

--- a/content/pages/meetup/2024/0327-nycu.rst
+++ b/content/pages/meetup/2024/0327-nycu.rst
@@ -1,5 +1,5 @@
 ========================================
-Meetup 2024 March 27st in NYCU
+Meetup 2024 March 27th in NYCU
 ========================================
 
 :date: 2024-03-01 22:27
@@ -9,7 +9,7 @@ Meetup 2024 March 27st in NYCU
 Date
 -----
 
-* Date: March 27st, 2024
+* Date: March 27th, 2024
 * Time: 18:30 -- 21:30 (3 hours)
 
 |
@@ -27,12 +27,12 @@ There will be many different subjects discussed at the same time.
 Subjects
 ------------------
 
-Sciwork activity process automation discussion
+sciwork activity process automation discussion
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Meetup events are important within the Sciwork community, serving as hubs for discussions and knowledges sharing. 
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
 We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
-the power of CI/CD and cutting-edge IT skills to enhance the Sciwork event experience. The works are divided into : 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
 
 1. Decide the format of the meetup page.
 2. Create the sesh event with api or other method.

--- a/content/pages/meetup/index.rst
+++ b/content/pages/meetup/index.rst
@@ -9,16 +9,16 @@ meetup
 meetup 2024
 ==============
 
-* `Meetup 2024 March 27st at NYCU
+* `Meetup 2024 March 27th at NYCU
   <{filename}2024/0327-nycu.rst>`__
 
-* `Meetup 2024 March 20st at NYCU
+* `Meetup 2024 March 20th at NYCU
   <{filename}2024/0320-nycu.rst>`__
 
-* `Meetup 2024 March 13st at NYCU
+* `Meetup 2024 March 13th at NYCU
   <{filename}2024/0313-nycu.rst>`__
 
-* `Meetup 2024 March 6st at NYCU
+* `Meetup 2024 March 6th at NYCU
   <{filename}2024/0306-nycu.rst>`__
 
 * `PyDoc Meetup 2024 March 10th at GoFreight Office


### PR DESCRIPTION
The dates on the March meetup page were mistakenly written as ending in st.
I also changed all the first word of sciwork to lowercase.