### PR TITLE
fix: specify purgecss to 5.0.0 to resolve ci failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ css:
 
 
 purgecss:
-	$(NPX) purgecss --config $(PURGECSSCONF) --css $(CSSFILE) -o output/theme/css
+	$(NPX) purgecss@5.0.0 --config $(PURGECSSCONF) --css $(CSSFILE) -o output/theme/css
 
 
 .PHONY: html help clean regenerate devserver deploy css purgecss


### PR DESCRIPTION
it seems the purgecss latest verseion (6.0.0) is unstable or incompatible with the Netlify build environment, necessitating a downgrade to 5.0.0.

errro message:
```
npx purgecss --config tailwind/purgecss.config.js --css theme/static/css/main.css -o output/theme/css
Failed during stage "building site": Build script returned non-zero exit code: 2
npx: installed 49 in 2.278s
Unexpected token "?"
```