### PR TITLE
Add information for the May sprint.

### DIFF
--- a/content/pages/conference/2024/03-workshop.rst
+++ b/content/pages/conference/2024/03-workshop.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 ------
 
 * 08:30 - 08:50	Check-in

--- a/content/pages/sprint/2023/08-hsinchu.rst
+++ b/content/pages/sprint/2023/08-hsinchu.rst
@@ -36,7 +36,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)
@@ -153,7 +153,7 @@ Career conversation QAs
 
 |
 
-Career Conversation Agneda
+Career Conversation Agenda
 +++++++++++++++++++++++++++
 
 * 11:00-12:00 Career Conversation 1

--- a/content/pages/sprint/2023/09-hsinchu.rst
+++ b/content/pages/sprint/2023/09-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)
@@ -159,7 +159,7 @@ conversation <#sign-up>`__, please purchase the **Dining Ticket + Career convers
 for this event. On the registration form, select **'I want to join the career conversation'** 
 and kindly fill up some relevant questions to give us an initial understanding of your background.
 
-Career Conversation Agneda
+Career Conversation Agenda
 +++++++++++++++++++++++++++
 
 * 11:00-11:30 Career Conversation 1

--- a/content/pages/sprint/2023/10-hsinchu.rst
+++ b/content/pages/sprint/2023/10-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating 
@@ -123,7 +123,7 @@ We release 4 career conversation tickets in October scisprint. To `register for 
 On the registration form, select **I want to join the career conversation** and kindly fill up some 
 relevant questions to give us an initial understanding of your background.
 
-Career Conversation Agneda
+Career Conversation Agenda
 +++++++++++++++++++++++++++
 
 * 11:00-11:30 Career Conversation 1

--- a/content/pages/sprint/2023/11-hsinchu.rst
+++ b/content/pages/sprint/2023/11-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2023/12-taipei.rst
+++ b/content/pages/sprint/2023/12-taipei.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2024/01-hsinchu.rst
+++ b/content/pages/sprint/2024/01-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2024/02-hsinchu.rst
+++ b/content/pages/sprint/2024/02-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)
@@ -149,7 +149,7 @@ Career conversation QAs
 
 |
 
-Career Conversation Agneda
+Career Conversation Agenda
 +++++++++++++++++++++++++++
 
 * 11:00-11:30 Career Conversation 1

--- a/content/pages/sprint/2024/03-taipei.rst
+++ b/content/pages/sprint/2024/03-taipei.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:30-11:00 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2024/04-hsinchu.rst
+++ b/content/pages/sprint/2024/04-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2024/05-hsinchu.rst
+++ b/content/pages/sprint/2024/05-hsinchu.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:00-10:30 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/2024/05-hsinchu.rst
+++ b/content/pages/sprint/2024/05-hsinchu.rst
@@ -39,22 +39,22 @@ Agenda
 
 |
 
-About the Scisprint
+About the scisprint
 ----------------------
 
 To join the sprint, please bring your laptop and `sign up <#sign-up>`__.  You are also 
 very welcome to bring your project. Please `contact us <#contact-us>`__ if you have any 
 questions.
 
-Scisprint, hosted by the sciwork community, is a monthly coding sprint. It would like to 
-facilitate discussions and exchanges among people in the fields of science, numerical 
+Scisprint, hosted by the sciwork community, is a monthly coding sprint. It is a place to 
+facilitate discussions and exchange information among people in the fields of science, numerical 
 computation, and engineering. Participants, regardless of experience level, can gain valuable 
-development insights in this event.
-
-.. This event includes a `hacking session <#hacking-session>`__ and `career conversation <#career-conversation>`__.
+development insights in this event. 
 
 We would like to provide a supportive and friendly environment for all attendees to support more developers
 to join in the open-source communities. 
+
+This event includes a `hacking session <#hacking-session>`__ and `career conversation <#career-conversation>`__.
 
 Hacking Session
 ------------------
@@ -108,6 +108,39 @@ team also maintains the sciwork conference page - conf.sciwork.dev.
 We have always been actively trying to provide users a better web browsing experience, including information 
 presentation and visual experience. Welcome to join us if you are interested in website maintence.
 
+Career Conversation
+--------------------
+
+Career conversation provides a chance to have relaxed discussions with experienced professionals from software 
+industry. If you have any career-related concerns you would like to explore, you are welcome to 
+sign up for this opportunity. Our goal is to assist you in gaining self-awareness, defining your career path, 
+and setting goals effectively.
+
+To `register <#sign-up>`__ for a career conversation, please purchase the **Dining Ticket + Career 
+conversation** ticket for this event. In the registration form, remember to select **I want to join the 
+career conversation** and kindly fill up some relevant questions to give us an initial 
+understanding of your background.
+
+Career conversation QAs
++++++++++++++++++++++++++++++
+
+ | Q: How is it conducted? 
+ | A: It is an individual 30-minutes career conversation. There are 4 time slots: 
+  11:00-11:30, 11:30-12:00, 13:30-14:00, and 14:00-14:30. Participants will be assigned to a specific 
+  time slot for their one-on-one career conversation.
+
+|
+
+ | Q: Who can sign up?
+ | A: Anyone who wants to talk about career-related topics is welcome to sign up.
+
+|
+
+ | Q: What preparations are needed before the conversation? 
+ | A: You only need to assist in filling out the relevant questions in the registration form. 
+      Just come with a relaxed and open mindset on the day of the event.
+
+|
 
 Sign Up
 ------------

--- a/content/pages/sprint/2024/05-hsinchu.rst
+++ b/content/pages/sprint/2024/05-hsinchu.rst
@@ -1,8 +1,8 @@
 =========================================
-(Tentative) Scisprint 2024 May in Hsinchu
+Scisprint 2024 May in Hsinchu
 =========================================
 
-:date: 2024-12-24 21:59
+:date: 2024-05-03 21:59
 :url: sprint/2024/05-hsinchu
 :save_as: sprint/2024/05-hsinchu.html
 
@@ -23,7 +23,7 @@ Agneda
 
 * 11:00-12:00 Coding Session 1
 
-* 12:00-13:20 Lunch Break & Group Discussion 1
+* 12:00-13:30 Lunch Break & Group Discussion 1
 
 * 13:30-14:20 Coding Session 2
 
@@ -67,14 +67,52 @@ in scisprint. Refer to `project list <#project-list>`__ below for more details.
 Project List
 +++++++++++++
 
-TBD
+modmesh
+^^^^^^^^^
+
+- **Related Subjects:** Python, C++, PDE
+- **Project Link:** `Github <https://github.com/solvcon/modmesh>`__
+- **Project Contact:** Yung-Yu Chen (discord: @yyc#7718), Chun-Hsu (@Chun-Hsu#6296)
+
+modmesh seamlessly mixes C++ and Python through pybind11, allowing you to leverage the strengths of 
+both programming languages for efficient PDE solving. We use Qt and Python to visualize the computation 
+results to give you a better understanding of your PDE solution. modmesh also supports mesh visualization, 
+currently in the Gmsh mesh file format. We have recently made efforts to improve the modmesh UI/UX.
+
+The design allows it to run on Windows, Linux, and MacOS. Everyone can use or contribute to modmesh.
+
+uTensor
+^^^^^^^^
+
+- **Project Link:** `GitHub <https://github.com/uTensor/uTensor>`__
+- **Project Contact:** Dboy(discord: @dboyliao#1295)
+
+uTensor is an extremely lightweight machine learning inference framework built on C++11. It simplifies model 
+deployment by seamlessly converting TensorFlow-trained models into efficient C++ files that can be used to infer 
+on the embedding device and integrate with optimized libraries such as CMSIS-NN by ARM with ease. Compared with 
+the binary files, C++ source code will provide greater flexibility to modify the trained model for the embedding engineers. 
+
+We provide the defaults for tensors, operators, and memory allocation. Just like the booming development of 
+machine learning, we are also actively developing the above functions. Welcome to join us.
+
+sciwork portal
+^^^^^^^^^^^^^^^
+
+- **Project Link:** `GitHub <https://github.com/sciwork/swportal>`__
+- **Project Contact:** Chester (discord: @chester), Wuxian (discord: @5x9527), Steve Chen (discord: @Steve Chen)
+
+sciwork portal is a project for maintaining our official website - sciwork.dev, which was built by Pelican 
+with tailwindCSS, and deployed by Netfliy. We create the promotional pages for meetup and sprint events. Our 
+team also maintains the sciwork conference page - conf.sciwork.dev.
+
+We have always been actively trying to provide users a better web browsing experience, including information 
+presentation and visual experience. Welcome to join us if you are interested in website maintence.
+
 
 Sign Up
 ------------
 
-TBD
-
-.. Please register at `kktix <https://sciwork.kktix.cc/events/scisprint-202311-hsinchu>`__.
+Please register at `kktix <https://sciwork.kktix.cc/events/scisprint-202405-hsinchu>`__.
 
 Venue
 -----

--- a/content/pages/sprint/2024/06-taipei.rst
+++ b/content/pages/sprint/2024/06-taipei.rst
@@ -14,7 +14,7 @@ Date
 
 |
 
-Agneda 
+Agenda 
 -------
 
 * 10:30-11:00 Arrival and Seating (Confirmation of registration information)

--- a/content/pages/sprint/index.rst
+++ b/content/pages/sprint/index.rst
@@ -16,7 +16,7 @@ Scisprint 2024
 * `(Tentative) Scisprint 2024 June in Taipei
   <{filename}2024/06-taipei.rst>`__
 
-* `(Tentative) Scisprint 2024 May in Hsinchu
+* `Scisprint 2024 May in Hsinchu
   <{filename}2024/05-hsinchu.rst>`__
 
 * `Scisprint 2024 April in Hsinchu


### PR DESCRIPTION
Add the project list and career conversation and update the registration link.

Also, fix the typo from "Agneda" to "Agenda" for some pages.