### PR TITLE
feat: add the 202406 meetup page and update meetup index

### DIFF
--- a/content/pages/meetup/2024/0605-nycu.rst
+++ b/content/pages/meetup/2024/0605-nycu.rst
@@ -1,0 +1,103 @@
+========================================
+Meetup 2024 June 5th in NYCU
+========================================
+
+:date: 2024-05-30 22:45
+:url: meetup/2024/0605-nycu
+:save_as: meetup/2024/0605-nycu.html
+
+Date
+-----
+
+* Date: June 5th, 2024
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+There will be many different subjects discussed at the same time.
+
+* 18:30-19:30 Free discussion
+* 19:30-21:30 Subjects discussion
+
+|
+
+Subjects
+------------------
+
+sciwork activity process automation discussion
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
+We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
+
+1. Decide the format of the meetup page.
+2. Create the sesh event with api or other method.
+3. Create the GitHub action to create the meetup page automatically.
+
+We had completed the TextFSM parser to parse the information on the meetup page and generate the new information of
+meetup page. Recently we are studying how to use API to create the discord event.
+
+Prepare upcoming sciwork events
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Additionally, we will discuss the following items to prepare `seminar summer 2024 <https://sciwork.dev/seminar/2024/06-seminar>`__
+and the upcoming events.
+
+* Task arrangement for volunteers
+* Promotion plan for upcoming events
+
+|
+
+Sign up
+------------
+
+The meetup is free. 
+Please register on `discord event <https://discord.com/channels/730297880140578906/1007075707400237067/1245743347289690284>`__. 
+Click the green check mark to participate the meetup.
+
+If you are using the discord app, you can find current event in the `meetup channel <https://discordapp.com/channels/730297880140578906/1007075707400237067>`__. 
+All recent sciwork event are at the top of the left sidebar.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source communities.
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+The meetup venue is at `國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU) <https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw"
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/meetup/2024/0612-nycu.rst
+++ b/content/pages/meetup/2024/0612-nycu.rst
@@ -1,0 +1,103 @@
+========================================
+Meetup 2024 June 12th in NYCU
+========================================
+
+:date: 2024-05-30 22:45
+:url: meetup/2024/0612-nycu
+:save_as: meetup/2024/0612-nycu.html
+
+Date
+-----
+
+* Date: June 12th, 2024
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+There will be many different subjects discussed at the same time.
+
+* 18:30-19:30 Free discussion
+* 19:30-21:30 Subjects discussion
+
+|
+
+Subjects
+------------------
+
+sciwork activity process automation discussion
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
+We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
+
+1. Decide the format of the meetup page.
+2. Create the sesh event with api or other method.
+3. Create the GitHub action to create the meetup page automatically.
+
+We had completed the TextFSM parser to parse the information on the meetup page and generate the new information of
+meetup page. Recently we are studying how to use API to create the discord event.
+
+Prepare upcoming sciwork events
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Additionally, we will discuss the following items to prepare `seminar summer 2024 <https://sciwork.dev/seminar/2024/06-seminar>`__
+and the upcoming events.
+
+* Task arrangement for volunteers
+* Promotion plan for upcoming events
+
+|
+
+Sign up
+------------
+
+The meetup is free. 
+Please register on `discord event <https://discord.com/channels/730297880140578906/1007075707400237067/1245743347289690284>`__. 
+Click the green check mark to participate the meetup.
+
+If you are using the discord app, you can find current event in the `meetup channel <https://discordapp.com/channels/730297880140578906/1007075707400237067>`__. 
+All recent sciwork event are at the top of the left sidebar.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source communities.
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+The meetup venue is at `國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU) <https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw"
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/meetup/2024/0619-nycu.rst
+++ b/content/pages/meetup/2024/0619-nycu.rst
@@ -1,0 +1,103 @@
+========================================
+Meetup 2024 June 19th in NYCU
+========================================
+
+:date: 2024-05-30 22:45
+:url: meetup/2024/0619-nycu
+:save_as: meetup/2024/0619-nycu.html
+
+Date
+-----
+
+* Date: June 19th, 2024
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+There will be many different subjects discussed at the same time.
+
+* 18:30-19:30 Free discussion
+* 19:30-21:30 Subjects discussion
+
+|
+
+Subjects
+------------------
+
+sciwork activity process automation discussion
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
+We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
+
+1. Decide the format of the meetup page.
+2. Create the sesh event with api or other method.
+3. Create the GitHub action to create the meetup page automatically.
+
+We had completed the TextFSM parser to parse the information on the meetup page and generate the new information of
+meetup page. Recently we are studying how to use API to create the discord event.
+
+Prepare upcoming sciwork events
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Additionally, we will discuss the following items to prepare `seminar summer 2024 <https://sciwork.dev/seminar/2024/06-seminar>`__
+and the upcoming events.
+
+* Task arrangement for volunteers
+* Promotion plan for upcoming events
+
+|
+
+Sign up
+------------
+
+The meetup is free. 
+Please register on `discord event <https://discord.com/channels/730297880140578906/1007075707400237067/1245743347289690284>`__. 
+Click the green check mark to participate the meetup.
+
+If you are using the discord app, you can find current event in the `meetup channel <https://discordapp.com/channels/730297880140578906/1007075707400237067>`__. 
+All recent sciwork event are at the top of the left sidebar.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source communities.
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+The meetup venue is at `國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU) <https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw"
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/meetup/2024/0626-nycu.rst
+++ b/content/pages/meetup/2024/0626-nycu.rst
@@ -1,0 +1,103 @@
+========================================
+Meetup 2024 June 26th in NYCU
+========================================
+
+:date: 2024-05-30 22:45
+:url: meetup/2024/0626-nycu
+:save_as: meetup/2024/0626-nycu.html
+
+Date
+-----
+
+* Date: June 26th, 2024
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+There will be many different subjects discussed at the same time.
+
+* 18:30-19:30 Free discussion
+* 19:30-21:30 Subjects discussion
+
+|
+
+Subjects
+------------------
+
+sciwork activity process automation discussion
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Meetup events are important within the sciwork community, serving as hubs for discussions and knowledges sharing. 
+We are excited to announce a special meetup where we'll delve into the realm of process automation, leveraging 
+the power of CI/CD and cutting-edge IT skills to enhance the sciwork event experience. The works are divided into : 
+
+1. Decide the format of the meetup page.
+2. Create the sesh event with api or other method.
+3. Create the GitHub action to create the meetup page automatically.
+
+We had completed the TextFSM parser to parse the information on the meetup page and generate the new information of
+meetup page. Recently we are studying how to use API to create the discord event.
+
+Prepare upcoming sciwork events
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Additionally, we will discuss the following items to prepare `seminar summer 2024 <https://sciwork.dev/seminar/2024/06-seminar>`__
+and the upcoming events.
+
+* Task arrangement for volunteers
+* Promotion plan for upcoming events
+
+|
+
+Sign up
+------------
+
+The meetup is free. 
+Please register on `discord event <https://discord.com/channels/730297880140578906/1007075707400237067/1245743347289690284>`__. 
+Click the green check mark to participate the meetup.
+
+If you are using the discord app, you can find current event in the `meetup channel <https://discordapp.com/channels/730297880140578906/1007075707400237067>`__. 
+All recent sciwork event are at the top of the left sidebar.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source communities.
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+The meetup venue is at `國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU) <https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw"
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/meetup/index.rst
+++ b/content/pages/meetup/index.rst
@@ -9,6 +9,18 @@ meetup
 meetup 2024
 ==============
 
+* `Meetup 2024 June 26th at NYCU
+  <{filename}2024/0626-nycu.rst>`__
+
+* `Meetup 2024 June 19th at NYCU
+  <{filename}2024/0619-nycu.rst>`__
+
+* `Meetup 2024 June 12th at NYCU
+  <{filename}2024/0612-nycu.rst>`__
+
+* `Meetup 2024 June 5th at NYCU
+  <{filename}2024/0605-nycu.rst>`__
+
 * `Meetup 2024 May 29th at NYCU
   <{filename}2024/0529-nycu.rst>`__
 


### PR DESCRIPTION
This commit add four 2024 June meetup page and the corresponding link in the index of meetup page.