### PR TITLE
Update the meetup information of 20240911

### DIFF
--- a/content/pages/meetup/2024/0911-nycu.rst
+++ b/content/pages/meetup/2024/0911-nycu.rst
@@ -1,0 +1,125 @@
+========================================
+Meetup 2024 September 11th in NYCU
+========================================
+
+:date: 2024-09-07 13:42
+:url: meetup/2024/0911-nycu
+:save_as: meetup/2024/0911-nycu.html
+
+Date
+-----
+
+* Date: September 11th, 2024
+* Time: 18:30 -- 21:30 (3 hours)
+
+|
+
+Agenda
+--------
+
+There will be many different subjects discussed at the same time.
+
++-----------------+--------------------------+---------------------------------+
+| Timetable       | Topic 1                  | Topic 2                         |
++=================+==========================+=================================+
+| 18:30 ~ 19:30   | free chat                                                  |
++-----------------+--------------------------+---------------------------------+
+| 19:30 ~ 21:00   | free chat                | modmesh discussion and training |
++-----------------+--------------------------+---------------------------------+
+| 21:00 ~ 21:30   | free chat                                                  |
++-----------------+--------------------------+---------------------------------+
+
+
+|
+
+Subjects
+------------------
+
+modmesh discussion and training
++++++++++++++++++++++++++++++++++++++
+
+discussion
+^^^^^^^^^^^^
+In the discussion session, 
+we will discuss the following topics simultaneously, 
+and you can choose the topic you are interested in.
+
+1. `Use Bezier curve to fit NACA 4-digit airfoil <https://github.com/solvcon/modmesh/issues/320>`__
+2. `Prototype profiler object serialization using JSON <https://github.com/solvcon/modmesh/issues/343>`__
+
+
+training
+^^^^^^^^^^^^
+
+If you are interested in the `modmesh project <https://github.com/solvcon/modmesh>`__, 
+but you are not familiar with the project, 
+we also have a training session for you, 
+and you can learn part of the following skills.
+
+1. Setting up and demonstrating modmesh.
+2. Basics of Git and GitHub.
+3. Writing Pybind11 and Unittest.
+4. Fundamentals of CMake, GNU Make, and GitHub Workflow.
+
+
+Free Chat
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+In this session, we could discuss any topic you are interested in.
+
+Additionally, we will discuss the following items to prepare the upcoming events.
+
+* Task arrangement for volunteers
+* Promotion plan for upcoming events
+
+|
+
+Sign up
+------------
+
+The meetup is free. 
+Please register on `discord event <https://discord.com/channels/730297880140578906/1007075707400237067/1281962066177036339>`__. 
+Click the green check mark to participate the meetup.
+
+If you are using the discord app, you can find current event in the `meetup channel <https://discordapp.com/channels/730297880140578906/1007075707400237067>`__. 
+All recent sciwork event are at the top of the left sidebar.
+
+|
+
+About Meetup
+------------
+
+Meetup is an event providing space for people to work on open source
+projects together. We welcome any subjects that may interest the attendees,
+and especially encourage code for science, engineering, and technology, which
+demand more critical discussions than other applications of computer
+programming.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source communities.
+
+To join the meetup, please bring your laptop and `sign up <#sign-up>`__. Please
+`contact us <#contact-us>`__ if you have any questions.
+
+|
+
+Venue
+-----
+
+The meetup venue is at `國立陽明交通大學 工程三館 3 樓 329 室 (Room 329, Engineering Building 3, NYCU) <https://goo.gl/maps/TgDYwohB3CBmQgww9>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d905.5596639949631!2d120.99673777209487!3d24.787280157478236!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360f96adabd7%3A0xedfd1ba0fa6c6bf7!2z5ZyL56uL6Zm95piO5Lqk6YCa5aSn5a24IOW3peeoi-S4iemkqA!5e0!3m2!1szh-TW!2stw!4v1678519228058!5m2!1szh-TW!2stw"
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/meetup/index.rst
+++ b/content/pages/meetup/index.rst
@@ -9,6 +9,9 @@ meetup
 meetup 2024
 ==============
 
+* `Meetup 2024 September 11th at NYCU
+  <{filename}2024/0911-nycu.rst>`__
+
 * `Meetup 2024 September 4th at NYCU
   <{filename}2024/0904-nycu.rst>`__
 


### PR DESCRIPTION
This pr is to discuss and add the agenda of the 9/11 meetup, which is refered in the issue #461.