### PR TITLE
Add sciwork conference 2024

### DIFF
--- a/content/pages/conference/2023/report.rst
+++ b/content/pages/conference/2023/report.rst
@@ -75,7 +75,7 @@ Humble Data
 We thank all the participants, including sponsors, volunteers, and contributors.
 We especially appreciate NYCU CS department for their help for the venue.
 The conference also went with the `Humble Data <https://humbledata.org>`__ workshop.
-The full list of the program is available at https://conf.sciwork.dev/program.
+The full list of the program is available at https://conf.sciwork.dev/2023/program.
 
 
 Scientific Programming

--- a/content/pages/conference/index.rst
+++ b/content/pages/conference/index.rst
@@ -6,26 +6,40 @@ Conference
 :url: conference
 :save_as: conference/index.html
 
+
+sciwork 2024
+===================
+
+`sciwork 2024 <https://conf.sciwork.dev/>`__ provides a physical venue to showcase the reasons for 
+our code, and how programming languages are used for scientific and engineering applications. You will 
+have the oppoptunity to learn more about their best practices, participate the professional DUCT TOPS training, 
+and become deeply involed with our open-source projects.
+
+- Date: December 14, 2024
+- Venue: Department of Physics/Center for Condensed Building, NTU, Taipei, Taiwan
+
+
 sciwork seminar summer 2024
 ===========================
 
-`sciwork seminar summer 2024 <{filename}2024/06-seminar.rst>`__
-
-report of sciwork 2023
-======================
-
-The event has concluded, and we appreciate everyone who participated! Feel free to review the report `here </conference/2023/report.html>`__!
+Please refer to `sciwork seminar summer 2024 <{filename}2024/06-seminar.rst>`__.
 
 
 sciwork 2023
-================================================
+================
     
-`sciwork 2023 <https://conf.sciwork.dev>`__ is to provide a physical venue to showcase how programming languages are 
+`sciwork 2023 <https://conf.sciwork.dev/2023>`__ is to provide a physical venue to showcase how programming languages are 
 used for scientific and engineering applications and their best practices. In addition 
 to scientific computing and high-performance computing, we also emphasize data management, 
 process, analytics, and visualization.
 
 - Date: December 9-10, 2023
-- Location: Microelectronics and Information Research Center, NYCU, Hsinchu, Taiwan
+- Venue: Microelectronics and Information Research Center, NYCU, Hsinchu, Taiwan
 
+
+Event report of sciwork 2023
+********************************
+
+sciwork 2023 has concluded, and we appreciate everyone who participated! 
+Feel free to review the report `here </conference/2023/report.html>`__!
 

--- a/content/pages/index.rst
+++ b/content/pages/index.rst
@@ -9,10 +9,14 @@ home
 
     <h2 class="text-2xl text-center mb-5">Upcoming Events</h2>
     <div class="flex flex-row flex-wrap text-center items-center justify-center">
-        <div class="md:w-1/2 w-full flex-col space-y-1">
-            <h3 class="text-lg">scisprint 2024 November in Hsinchu</h3>
+        <div class="md:w-1/2 w-full flex flex-row flex-wrap justify-center space-y-1">
+            <h3 class="text-lg">sciwork conference 2024 in NTU Physics</h3>
             <div class="flex-col space-x-5">
-                <a href="/sprint/2024/11-Hsinchu">Introduction</a>
+                <a href="/conference/index.html#sciwork_2024">Introduction</a>
+                &nbsp;&nbsp;
+            </div>
+            <div class="flex-col space-x-5">
+                <a href="https://conf.sciwork.dev/">Conference website</a>
                 &nbsp;&nbsp;
             </div>
         </div>


### PR DESCRIPTION
This PR is mainly to complete the following tasks:
1.  create a section for swc2024.
2. fix the link for swc2023.
3. update the upcoming event in homepage.

#### sciwork conference 2024
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/48e723be-3a91-4b5e-87ce-dfa86ed1fbf1">

#### Upcoming event in homepage
<img width="809" alt="image" src="https://github.com/user-attachments/assets/dc33de6e-8247-494c-a107-88ab01427c03">
