### PR TITLE
CSS Optimize: Only title in td should be center

### DIFF
--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -192,17 +192,15 @@ td {
   vertical-align: top;
 }
 
-td {
+.docutil > td {
   text-align: center;
 }
 
-td > .first {
+.docutil >td > .first {
   text-align: center;
 }
 
-td > p,
-ol,
-li {
+.docutil > td > p, ol, li {
   text-align: left;
 }
 

--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -193,6 +193,16 @@ td {
 }
 
 td {
+  text-align: center;
+}
+
+td > p,
+ol,
+li {
+  text-align: left;
+}
+
+td {
   border-bottom: solid #cccccc;
   border-right: solid #cccccc;
 }

--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -192,15 +192,15 @@ td {
   vertical-align: top;
 }
 
-.docutils > td {
+.docutils td {
   text-align: center;
 }
 
-.docutils >td > .first {
+.docutils td > .first {
   text-align: center;
 }
 
-.docutils > td > p, ol, li {
+.docutils td > p, ol, li {
   text-align: left;
 }
 

--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -196,6 +196,10 @@ td {
   text-align: center;
 }
 
+td > .first {
+  text-align: center;
+}
+
 td > p,
 ol,
 li {

--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -192,15 +192,15 @@ td {
   vertical-align: top;
 }
 
-.docutil > td {
+.docutils > td {
   text-align: center;
 }
 
-.docutil >td > .first {
+.docutils >td > .first {
   text-align: center;
 }
 
-.docutil > td > p, ol, li {
+.docutils > td > p, ol, li {
   text-align: left;
 }
 


### PR DESCRIPTION
Thanks @chestercheng providing the issue, I already optimize the css with only title should be center. It reserve the description space in `<td>` HTML DOM and we can add some description in agenda.

![image](https://github.com/user-attachments/assets/e944c0f4-6ff3-41fa-bd40-b37c12b8f202)

Since #525 doesn't merge yet, it may not be able to preview it, so I add a screenshot above. Change to Open when #525 merged.

Fix: #526 