### PR TITLE
Add SITCON 2025 sciwork booth page

### DIFF
--- a/content/pages/conference/2025/03-sitcon.rst
+++ b/content/pages/conference/2025/03-sitcon.rst
@@ -1,0 +1,51 @@
+====================================================
+sciwork booth in SITCON 2025 
+====================================================
+
+:date: 2024-05-09 21:00
+:url: events/2025/03-sitcon
+:save_as: events/2025/03-sitcon.html
+
+
+Sciwork is excited to participate in `SITCON 2025 <https://sitcon.org/2025/>`__, the biggest student tech community event in Taiwan!
+If you are passionate about coding, open-source collaboration, or scientific computing, our booth is the place to be. 
+This year at SITCON, we have prepared:
+
+* **Community Introduction**: Learn about our community and how you can be part of it!
+* **Card Game**: Play and explore how your coding skills connect to the world of scientific computing!
+* **Open Source Discussions**: Whether you're new to open source or an experienced contributor, come chat with us about projects, collaboration, and innovation!
+
+Whether you are an experienced developer passionate about open source or a student just starting your journey, 
+we welcome you to visit the Sciwork booth! 
+
+Date
+----
+
+* Date: 8th March, Saturday, 2025
+* Time: 9:00 -- 16:00
+
+|
+
+Venue
+-----
+
+`中央研究院 人文社會科學館 (Humanities and Social Sciences Building, Academia Sinica)
+<https://maps.app.goo.gl/697uzMh7ty5FzdbR7>`__.
+
+.. raw:: html
+
+  <div style="overflow:hidden; padding-bottom:56.25%; position:relative; height:0;">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d14459.125077801129!2d121.611534!3d25.041496!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3442ab46b3aaaaab%3A0x6ad0b8243ddc70ef!2z5Lit5aSu56CU56m26Zmi5Lq65paH56S-5pyD56eR5a246aSo!5e0!3m2!1szh-TW!2stw!4v1740835666132!5m2!1szh-TW!2stw" 
+      style="left:0; top:0; height:100%; width:100%; position:absolute; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade">
+    </iframe>
+  </div>
+
+|
+
+Contact us
+----------
+
+* sciwork: https://sciwork.dev/
+* discord: https://discord.gg/6MAkFrD
+* email: `contact@sciwork.dev (subject: I want to lead a project in scisprint) <mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint>`__
+* flickr: https://www.flickr.com/photos/sciwork/albums

--- a/content/pages/conference/index.rst
+++ b/content/pages/conference/index.rst
@@ -7,6 +7,11 @@ Conference
 :save_as: conference/index.html
 
 
+sciwork booth in SITCON 2025 
+============================
+Please refer to `sciwork booth in SITCON 2025  <{filename}2025/03-sitcon.rst>`__.
+
+
 sciwork 2024
 ===================
 


### PR DESCRIPTION
I add the web page for sciwork booth at upcoming SITCON 2025.
The page is added under `/conference/2025` folder and mapped to `events/2025/03-sitcon.html` on website.