### PR TITLE
feat(homepage): refine the content and add GSAP animation at homepage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,11 @@
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "vscode.css-language-features"
   }
 }

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function AboutLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function BlogLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/conference/layout.tsx
+++ b/app/conference/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function ConferenceLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import type { Viewport } from "next";
 import { Inter, Yanone_Kaffeesatz } from "next/font/google";
-import Container from "@/components/Container";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import "./globals.css";
@@ -86,7 +85,7 @@ export default function RootLayout({
         )}
       >
         <Header />
-        <Container as="main">{children}</Container>
+        {children}
         <Footer />
       </body>
     </html>

--- a/app/meetup/layout.tsx
+++ b/app/meetup/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function MeetupLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
 import Content from "@/components/Content";
 import UpcomingEvents from "@/components/UpcomingEvents";
+import HomepageHero from "@/components/Homepage/Hero";
+// import HomepageDescription from "@/components/Homepage/Description";
 
 const Home: React.FC = () => {
   return (
     <>
+      <HomepageHero />
+      {/* <HomepageDescription /> */}
       <UpcomingEvents className="mb-10" />
       <Content filePath="index.mdx" />
     </>

--- a/app/project/layout.tsx
+++ b/app/project/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function ProjectLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/sprint/layout.tsx
+++ b/app/sprint/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function SprintLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/app/training/layout.tsx
+++ b/app/training/layout.tsx
@@ -1,0 +1,9 @@
+import Container from "@/components/Container";
+
+export default function TrainingLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return <Container as="main">{children}</Container>
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import clsx from "clsx";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import Banner from "@/components/Banner";
 import NavLink from "@/components/NavLink";
@@ -45,6 +46,9 @@ const MenuButton = ({
 const Header: React.FC = () => {
   const [opened, setOpened] = useState(false);
   const [showDarkBackground, setShowDarkBackground] = useState(false);
+
+  const pathname = usePathname();
+  const isHomePage = pathname === "/";
 
   const onToggleMenu = () => setOpened(!opened);
   const onNavLinkClick = (e: React.MouseEvent) => {
@@ -112,7 +116,9 @@ const Header: React.FC = () => {
           </div>
         </div>
       </nav>
-      <Banner />
+      {isHomePage ? (
+        <></>
+      ) : (<Banner />)}
     </header>
   );
 };

--- a/components/Homepage/Description.tsx
+++ b/components/Homepage/Description.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRef } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import MotionPathPlugin from 'gsap/MotionPathPlugin';
+import ScrollTrigger from 'gsap/ScrollTrigger';
+
+import "./Hero.css"; // Import your CSS file for styles
+
+import Image from "next/image";
+import iconImg from "@/assets/android-chrome-512x512.png";
+
+gsap.registerPlugin(useGSAP, MotionPathPlugin, ScrollTrigger); // register the MotionPathPlugin
+
+// ------- Kudos to Osmo [https://osmo.supply/] ------- //
+
+const HomepageDescription: React.FC = () => {
+
+    const container = useRef<HTMLDivElement>(null);
+
+    useGSAP(() => {
+        // --- ORANGE PANEL ---
+        gsap.from(".line-2", {
+            scrollTrigger: {
+                trigger: ".orange",
+                scrub: true,
+                pin: true,
+                start: "top top",
+                end: "+=100%"
+            },
+            scaleX: 0,
+            transformOrigin: "left center",
+            ease: "none"
+        });
+    }, { scope: container });
+
+    return (
+        <div ref={container} className="relative flex items-center justify-center w-full h-screen bg-cover bg-center bg-no-repeat bg-black opacity-70">
+            <section className="cloneable panel orange">
+                <span className="line line-2"></span>
+                <p>This orange panel gets pinned when its top edge hits the top of the viewport, then the line's animation is linked with the scroll position until it has traveled 100% of the viewport's height (<code>end: "+=100%"</code>), then the orange panel is unpinned and normal scrolling resumes. Padding is added automatically to push the rest of the content down so that it catches up with the scroll when it unpins. You can set <code>pinSpacing: false</code> to prevent that if you prefer.</p>
+            </section>
+        </div>
+    );
+}
+
+export default HomepageDescription;

--- a/components/Homepage/Hero.css
+++ b/components/Homepage/Hero.css
@@ -1,0 +1,152 @@
+/* ------- Osmo [https://osmo.supply/] ------- */
+/* Osmo UI: https://slater.app/10324/23333.css */
+
+.cloneable {
+    padding: 1rem;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    display: flex;
+    position: relative;
+}
+
+.looping-words {
+    height: 2.7em;
+    padding-left: .1em;
+    padding-right: .1em;
+    font-size: 9vw;
+    line-height: .9;
+    position: relative;
+}
+
+.looping-words__list {
+    text-align: center;
+    /* text-transform: uppercase; */
+    font-family: "Yanone Kaffeesatz", arial, serif;
+    white-space: nowrap;
+    flex-flow: column;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    font-weight: 700;
+    list-style: none;
+    display: flex;
+    position: relative;
+}
+
+.looping-words__list.is--primary {
+    color: var(--color-primary);
+}
+
+.looping-words__list.is--gray {
+    color: var(--color-neutral-500);
+}
+
+.looping-words__fade {
+    /* @apply bg-gradient-to-b from-neutral-300 via-transparent to-neutral-300; */
+    pointer-events: none;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.looping-words__fade.is--radial {
+    background-image: radial-gradient(circle closest-side at 50% 50%, transparent 64%, var(--color-neutral-400) 93%);
+    width: 140%;
+    display: block;
+    left: -20%;
+}
+
+.looping-words__selector {
+    pointer-events: none;
+    width: 100%;
+    height: .9em;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.looping-words__edge {
+    @apply border-t-[0.035em] border-l-[0.035em] border-red-400;
+    width: .125em;
+    height: .125em;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.looping-words__edge.is--2 {
+    left: auto;
+    right: 0;
+    transform: rotate(90deg);
+}
+
+.looping-words__edge.is--3 {
+    inset: auto 0 0 auto;
+    transform: rotate(180deg);
+}
+
+.looping-words__edge.is--4 {
+    top: auto;
+    bottom: 0;
+    transform: rotate(270deg);
+}
+
+.looping-words__containers {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+}
+
+.looping-words__p {
+    margin: 0;
+}
+
+.line {
+    width: 100%;
+    max-width: 800px;
+    height: 8px;
+    margin: 0 0 10px 0;
+    position: relative;
+    display: inline-block;
+    background-color: rgba(255, 255, 255, 1);
+}
+
+.panel p {
+    max-width: 80ch;
+    display: block;
+}
+
+.panel {
+    flex-direction: column;
+    font-size: 1.1em;
+}
+
+.panel h1 {
+    font-size: 1.8em;
+    color: white;
+    font-weight: 300;
+    margin: 0 auto;
+}
+
+.panel.description {
+    padding-bottom: 60px;
+}
+
+.panel p,
+.panel li {
+    color: black;
+    font-weight: 400;
+    text-align: left;
+    font-size: 0.8em;
+    line-height: 1.5em;
+    margin: 0.3em 0 1em 0;
+}
+
+.panel li {
+    margin: 0;
+}

--- a/components/Homepage/Hero.tsx
+++ b/components/Homepage/Hero.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useRef } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import MotionPathPlugin from 'gsap/MotionPathPlugin';
+import ScrollTrigger from 'gsap/ScrollTrigger';
+
+import "./Hero.css"; // Import your CSS file for styles
+
+import Image from "next/image";
+import iconImg from "@/assets/android-chrome-512x512.png";
+
+gsap.registerPlugin(useGSAP, MotionPathPlugin, ScrollTrigger); // register the MotionPathPlugin
+
+// ------- Kudos to Osmo [https://osmo.supply/] ------- //
+
+const HomepageHero: React.FC = () => {
+
+    const container = useRef<HTMLDivElement>(null);
+
+    useGSAP(() => {
+        // GSAP animation for SVG
+        const wordList = document.querySelector('[data-looping-words-list]');
+        const words = Array.from(wordList.children);
+        const totalWords = words.length;
+        const wordHeight = 100 / totalWords; // Offset as a percentage
+        const edgeElement = document.querySelector('[data-looping-words-selector]');
+        let currentIndex = 0;
+
+        const updateEdgeWidth = () => {
+            const centerIndex = (currentIndex + 1) % totalWords;
+            const centerWord = words[centerIndex];
+            const centerWordWidth = centerWord.getBoundingClientRect().width;
+            const listWidth = wordList.getBoundingClientRect().width;
+            const percentageWidth = (centerWordWidth / listWidth) * 100;
+            gsap.to(edgeElement, {
+                width: `${percentageWidth}%`,
+                duration: 0.5,
+                ease: 'Expo.easeOut',
+            });
+        }
+        const moveWords = () => {
+            currentIndex++;
+            gsap.to(wordList, {
+                yPercent: -wordHeight * currentIndex,
+                duration: 1.2,
+                ease: 'elastic.out(1, 0.85)',
+                onStart: updateEdgeWidth,
+                onComplete: function () {
+                    if (currentIndex >= totalWords - 3) {
+                        wordList.appendChild(wordList.children[0]);
+                        currentIndex--;
+                        gsap.set(wordList, { yPercent: -wordHeight * currentIndex });
+                        words.push(words.shift());
+                    }
+                }
+            });
+        }
+
+        updateEdgeWidth();
+        gsap.timeline({ repeat: -1, delay: 1 })
+            .call(moveWords)
+            .to({}, { duration: 2 })
+            .repeat(-1);
+
+    }, { scope: container });
+
+    return (
+        <div ref={container} className="relative flex items-center justify-center">
+            <div className="absolute inset-0 w-full h-screen bg-cover bg-center bg-no-repeat bg-black opacity-90" />
+            <div className="relative z-10 flex items-center justify-center w-full h-full text-white">
+                <section className="cloneable">
+                    <div className="looping-words">
+                        <div className="looping-words__containers">
+                            <ul data-looping-words-list="" className="looping-words__list">
+                                <li className="looping-words__list">
+                                    <p className="looping-words__p">science</p>
+                                </li>
+                                <li className="looping-words__list">
+                                    <p className="looping-words__p">code</p>
+                                </li>
+                                <li className="looping-words__list">
+                                    <p className="looping-words__p">open source</p>
+                                </li>
+                                <li className="looping-words__list">
+                                    <p className="looping-words__p flex items-center"><Image
+                                        src={iconImg} alt='sciwork logo' className='w-[8vw] h-[8vw]' />sciwork</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <div className="looping-words__fade"></div>
+                        <div data-looping-words-selector="" className="looping-words__selector">
+                            <div className="looping-words__edge"></div>
+                            <div className="looping-words__edge is--2"></div>
+                            <div className="looping-words__edge is--3"></div>
+                            <div className="looping-words__edge is--4"></div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}
+
+export default HomepageHero;

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@gsap/react": "^2.1.2",
     "clsx": "^2.1.1",
     "globby": "^14.1.0",
     "gray-matter": "^4.0.3",
+    "gsap": "^3.12.7",
     "next": "15.1.6",
     "next-mdx-remote": "^5.0.0",
     "react": "^19.0.0",
@@ -40,5 +42,6 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,6 +189,11 @@
   dependencies:
     prop-types "^15.8.1"
 
+"@gsap/react@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@gsap/react/-/react-2.1.2.tgz#bfc055a41b402e8d1dc56839e9d077407027b0a0"
+  integrity sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -1943,6 +1948,11 @@ gray-matter@^4.0.3:
     kind-of "^6.0.2"
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
+
+gsap@^3.12.7:
+  version "3.12.7"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.12.7.tgz#1b690def901ac9b21d4909f39c2b52418154463d"
+  integrity sha512-V4GsyVamhmKefvcAKaoy0h6si0xX7ogwBoBSs2CTJwt7luW0oZzC0LhdkyuKV8PJAXr7Yaj8pMjCKD4GJ+eEMg==
 
 has-bigints@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
This PR is the first try of refine homepage, I've added the animation at the landing page, you may check at the preview.

Also here are some changes that may affect to others or developments afterward:
1. **Adding Nested Layouts**: Due to the component `Container`, it will have padding and not fullscreen width if I want to develop animation at homepage, so I created nested layout under every paths; Therefore, the root layout, which homepage would only render this, removed `Container` for a better animation display. <br><br>
2. **Adding Nested Components**: I'm not really familiar to Next.js, I just created a `homepage` folder under `/components/` to create each parts of animation at homepage, wondering if this is a good behavior or not? I would like to learn comment from @jack482653.