### PR TITLE
add 2025 Oct scisprint page

### DIFF
--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -6,12 +6,14 @@ import constants from "@/configurations/constants";
 import AgendaTable from "@/components/AgendaTable";
 import Map from "@/components/Map";
 import TagIcon from "@/components/icons/TagIcon";
+import RegistrationButton from "@/components/RegistrationButton";
 import * as markdown from "@/utils/markdown";
 
 const components = {
   Map,
   AgendaTable,
   TagIcon,
+  RegistrationButton,
 };
 
 const options = {

--- a/components/RegistrationButton.tsx
+++ b/components/RegistrationButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface RegistrationButtonProps {
+  url: string;
+  text?: string;
+  className?: string;
+}
+
+export default function RegistrationButton({ 
+  url, 
+  text = "Register Now",
+  className = ""
+}: RegistrationButtonProps) {
+  return (
+    <a 
+      href={url} 
+      target="_blank" 
+      rel="noopener noreferrer"
+      className={className}
+    >
+      <button 
+        style={{
+          backgroundColor: "#3BA55D",
+          color: "white",
+          padding: "10px 20px",
+          border: "none",
+          borderRadius: "6px",
+          cursor: "pointer",
+          fontSize: "1rem",
+          fontWeight: "bold"
+        }}
+      >
+        {text}
+      </button>
+    </a>
+  );
+}

--- a/contents/sprint/2025/10-hsinchu.mdx
+++ b/contents/sprint/2025/10-hsinchu.mdx
@@ -14,26 +14,10 @@ location: "Center for Theory and Computation (National Tsing Hua University)"
 
 Please complete your registration through [KKTIX](https://sciwork.kktix.cc/events/scisprint-202510-hsinchu).
 
-<a 
-  href="https://sciwork.kktix.cc/events/scisprint-202510-hsinchu" 
-  target="_blank" 
-  rel="noopener noreferrer"
->
-  <button 
-    style={{
-      backgroundColor: "#3BA55D",
-      color: "white",
-      padding: "10px 20px",
-      border: "none",
-      borderRadius: "6px",
-      cursor: "pointer",
-      fontSize: "1rem",
-      fontWeight: "bold"
-    }}
-  >
-    Sign Up on KKTIX
-  </button>
-</a>
+<RegistrationButton 
+  url="https://sciwork.kktix.cc/events/scisprint-202510-hsinchu" 
+  text="Sign Up on KKTIX"
+/>
 
 You can also stay connected and join discussions in our [Discord sprint channel](https://discord.gg/gMkDTm63Xy)
 

--- a/contents/sprint/2025/10-hsinchu.mdx
+++ b/contents/sprint/2025/10-hsinchu.mdx
@@ -1,0 +1,183 @@
+---
+date: "2025-10-18 10:00"
+eventTime: "10:00 - 17:00"
+title: "scisprint 2025 October in Hsinchu"
+location: "Center for Theory and Computation (National Tsing Hua University)"
+---
+
+## Date
+
+- **Date**: Saturday, October 18, 2025
+- **Time**: 10:00 - 17:00 (7 hours)
+
+## Sign Up
+
+Please complete your registration through [KKTIX](https://sciwork.kktix.cc/events/scisprint-202510-hsinchu).
+
+<a 
+  href="https://sciwork.kktix.cc/events/scisprint-202510-hsinchu" 
+  target="_blank" 
+  rel="noopener noreferrer"
+>
+  <button 
+    style={{
+      backgroundColor: "#3BA55D",
+      color: "white",
+      padding: "10px 20px",
+      border: "none",
+      borderRadius: "6px",
+      cursor: "pointer",
+      fontSize: "1rem",
+      fontWeight: "bold"
+    }}
+  >
+    Sign Up on KKTIX
+  </button>
+</a>
+
+You can also stay connected and join discussions in our [Discord sprint channel](https://discord.gg/gMkDTm63Xy)
+
+## Agenda
+
+<AgendaTable>
+  <AgendaTable.Row time="10:00 - 10:30">
+    <AgendaTable.Topic title="Arrival and Seating (Confirmation of registration
+  information)" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="10:30 - 11:00">
+    <AgendaTable.Topic title="Project Introduction" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="11:00 - 12:00">
+    <AgendaTable.Topic title="Coding Session 1" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="12:00 - 13:30">
+    <AgendaTable.Topic title="Lunch Break" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="13:30 - 14:30">
+    <AgendaTable.Topic title="Coding Session 2" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="14:30 - 15:30">
+    <AgendaTable.Topic title="Group Discussion" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="15:30 - 16:30">
+    <AgendaTable.Topic title="Final Sprint" />
+  </AgendaTable.Row>
+  <AgendaTable.Row time="16:30 - 17:00">
+    <AgendaTable.Topic title="Project Summary & Closing" />
+  </AgendaTable.Row>
+</AgendaTable>
+
+
+## About the Scisprint
+
+To join the sprint, please bring your laptop and [sign up](#sign-up).
+You are also very welcome to bring your project. Please [contact
+us](#contact-us) if you have any questions.
+
+Scisprint, hosted by the sciwork community, is a monthly coding sprint.
+It would like to facilitate discussions and exchanges among people in
+the fields of science, numerical computation, and engineering.
+Participants, regardless of experience level, can gain valuable
+development insights in this event.
+
+We would like to provide a supportive and friendly environment for all
+attendees to support more developers to join in the open-source
+communities.
+
+## Coding Session
+
+It aims to encourage collaboration and interaction among developers
+through project participation. The projects cover various fields,
+including but not limited to science, numerical computation, and
+engineering. You are also encouraged to share your own projects in
+scisprint. Refer to [project list](#project-list) below for more
+details.
+
+## Project List
+
+### modmesh
+
+- **Related Subjects:** Python, C++, PDE
+- **Project Link:** [GitHub](https://github.com/solvcon/modmesh)
+- **Project Contact:** Yung-Yu Chen (discord: \@yyc#7718)
+
+modmesh seamlessly mixes C++ and Python through pybind11, allowing you
+to leverage the strengths of both programming languages for efficient
+PDE solving. We use Qt and Python to visualize the computation results
+to give you a better understanding of your PDE solution. modmesh also
+supports mesh visualization, currently in the Gmsh mesh file format. We
+have recently made efforts to improve the modmesh UI/UX.
+
+The design allows it to run on Windows, Linux, and MacOS. Everyone can
+use or contribute to modmesh.
+
+### AItlas
+
+- **Project Link:** [GitHub](https://github.com/Droidtown/AItlas)
+- **Project Contact:** PeterWolf (discord: \@PeterWolf#1422),
+  [Discord](https://discord.com/invite/tYq4qUY4)
+
+A knowledge graph should formally represent relations between/among
+entities and provide insights for semantic computation in natural
+language understanding (NLU). The representation is usually like a net
+2D or atlas in 3D and higher dimensions. In recent years, this is
+usually called RAG. We believe a knowledge graph (thus KG) can do more
+for AI, thus named our project AI+Atlas = AItlas.
+
+### sciwork portal
+
+- **Project Link:** [GitHub](https://github.com/sciwork/swportal)
+- **Project Contact:** Chester (discord: \@chester), Wuxian (discord:
+  \@5x9527), Steve Chen (discord: \@Steve Chen)
+
+Sciwork Portal is a project for maintaining our official website -
+Sciwork.dev, which was built by Pelican with tailwindCSS, and deployed
+by Netfliy. We create the promotional pages for meetup and sprint
+events. Our team also maintains the sciwork conference page -
+conf.sciwork.dev.
+
+We have always been actively trying to provide users a better web
+browsing experience, including information presentation and visual
+experience. Welcome to join us if you are interested in website
+maintence.
+
+### uTensor
+
+- **Project Link:** [GitHub](https://github.com/uTensor/uTensor)
+- **Project Contact:** Dboy(discord: \@dboyliao#1295)
+
+uTensor is an extremely lightweight machine learning inference framework
+built on C++11. It simplifies model deployment by seamlessly converting
+TensorFlow-trained models into efficient C++ files that can be used to
+infer on the embedding device and integrate with optimized libraries
+such as CMSIS-NN by ARM with ease.
+
+
+## Venue
+
+### Venue Map
+
+[前沿理論及計算研究中心 (國立清華大學第三綜合大樓 A 區 5
+樓)](https://goo.gl/maps/EH2wWtkLQ8qLWd669).
+
+[Center for Theory and Computation (Rm. P518, 3rd General Building,
+National Tsing Hua University)](https://goo.gl/maps/4i2K2XvJqw2J42pv5).
+
+<Map src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28976.98152829823!2d120.96353258312313!3d24.79125198152699!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3468360c81cfffe3%3A0xd7d529328f01b825!2z5ZyL56uL5riF6I-v5aSn5a2456ys5LiJ57ac5ZCI5aSn5qiT!5e0!3m2!1szh-TW!2stw!4v1662888048158!5m2!1szh-TW!2stw" />
+
+### Floor Plan
+
+Once you arrive at the 3rd General Building, take the elevator or stairs to the **5th floor (Section A)**.  
+The session will be held in **Room P518**.  
+
+Here is the floor plan to help you locate the room and nearby facilities:
+![NTHU_CTC_floor_plan](/sprint/2025/NTHU_CTC_floor_plan.jpg)
+
+
+## Contact us
+
+- sciwork: [https://sciwork.dev/](https://sciwork.dev/)
+- Discord: [https://discord.gg/6MAkFrD](https://discord.gg/6MAkFrD)
+- Email: [contact@sciwork.dev (subject: I want to lead a project in
+  scisprint)](mailto:contact@sciwork.dev?subject=[sciwork]%20I%20want%20to%20lead%20a%20project%20in%20scisprint)
+- flickr: [https://www.flickr.com/photos/sciwork/albums](https://www.flickr.com/photos/sciwork/albums)

--- a/contents/sprint/2025/10-hsinchu.mdx
+++ b/contents/sprint/2025/10-hsinchu.mdx
@@ -98,8 +98,7 @@ use or contribute to modmesh.
 ### AItlas
 
 - **Project Link:** [GitHub](https://github.com/Droidtown/AItlas)
-- **Project Contact:** PeterWolf (discord: \@PeterWolf#1422),
-  [Discord](https://discord.com/invite/tYq4qUY4)
+- **Project Contact:** PeterWolf (discord: \@PeterWolf#1422)
 
 A knowledge graph should formally represent relations between/among
 entities and provide insights for semantic computation in natural


### PR DESCRIPTION
Add 2025 October scisprint page
Also includes template modifications:
1. Update date format from "18th October, Saturday, 2025" → "Saturday, October 18, 2025"
2. Move up "Sign Up" section to make it more prominent

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/92d680c2-667a-4208-9327-5aa590a02c3d" />
