### PR TITLE
feat: rename modmesh to solvcon in project documentation and footer links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -52,10 +52,10 @@ const Footer: React.FC = () => {
             <h3 className="text-red-800">project</h3>
             <div className="pl-2">
               <Link
-                href="/project#modmesh"
+                href="/project#solvcon"
                 className="block text-white no-underline"
               >
-                modmesh
+                solvcon
               </Link>
               <Link
                 href="/project#python-official-documents-translation-zh-tw"

--- a/contents/project/index.mdx
+++ b/contents/project/index.mdx
@@ -5,7 +5,7 @@ title: project
 url: project
 ---
 
-# modmesh
+# solvcon
 
 <div className="mb-5 flex">
   <span className="space-x-2 px-2">
@@ -22,18 +22,20 @@ url: project
   </span>
 </div>
 
-- **Repository Link:** [GitHub](https://github.com/solvcon/modmesh)
+- **Repository Link:** [GitHub](https://github.com/solvcon/solvcon)
 - **Leader:** [Yung-Yu Chen](https://twitter.com/yungyuc)
 
-modmesh seamlessly mixes C++ and Python through pybind11, allowing you
+solvcon seamlessly mixes C++ and Python through pybind11, allowing you
 to leverage the strengths of both programming languages for efficient
 PDE solving. We use Qt and Python to visualize the computation results
-to give you a better understanding of your PDE solution. modmesh also
+to give you a better understanding of your PDE solution. solvcon also
 supports mesh visualization, currently in the Gmsh mesh file format. We
-have recently made efforts to improve the modmesh UI/UX.
+have recently made efforts to improve the solvcon UI/UX.
 
 The design allows it to run on Windows, Linux, and MacOS. Everyone can
-use or contribute to modmesh.
+use or contribute to solvcon.
+
+(previously *modmesh*, check the [issue](https://github.com/solvcon/solvcon/issues/904) about the name change)
 
 # Python Official Documents Translation (zh_TW)
 


### PR DESCRIPTION
This pull request updates references to the project previously called "modmesh" to the new name "solvcon" throughout the website. The changes ensure consistency in navigation, documentation, and project description.

**Project renaming and documentation updates:**

- `components/Footer.tsx`: Updated the project name from `modmesh` to `solvcon` in the footer navigation link and display text.
- `contents/project/index.mdx`: Changed the main heading and all references from `modmesh` to `solvcon` in the project documentation, including the repository link, descriptive text, and added a note about the name change.