### PR TITLE
fix: update venue map link for scisprint taipei July 2026 page

### DIFF
--- a/contents/sprint/2026/07-taipei.mdx
+++ b/contents/sprint/2026/07-taipei.mdx
@@ -149,7 +149,7 @@ we’re removing the  local environment tax for students and devs.
 
 ### Venue Map
 
-[Happ. 小樹屋｜香杉分館 501 (104 臺北市中山區集英里民權西路56號2樓)](https://maps.app.goo.gl/t8AwzjccGh5Bk76B6).
+[Happ. 小樹屋｜香杉分館 501 (104 臺北市中山區集英里民權西路56號2樓)](https://maps.app.goo.gl/5dk5FGQQehhtRVCH6).
 
 
 <Map src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3614.159049349968!2d121.51780817590365!3d25.06259783713849!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3442a9f39eb9f6b5%3A0x5eb047069ee762d!2zSGFwcC4g5bCP5qi55bGL772c6aaZ5p2J5YiG6aSo!5e0!3m2!1szh-TW!2stw!4v1782834702878!5m2!1szh-TW!2stw" />


### PR DESCRIPTION
corrected venue map link